### PR TITLE
Bug fixes for `Circuit.__repr_svg__`

### DIFF
--- a/cirq-core/cirq/contrib/svg/empty_moments_example.ipynb
+++ b/cirq-core/cirq/contrib/svg/empty_moments_example.ipynb
@@ -1,0 +1,616 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be4b9f5d",
+   "metadata": {},
+   "source": [
+    "## Tests the code for circuits with empty moments\n",
+    "\n",
+    "Working of the previous code (cirq.contrib.svg.svg) is shown as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a27206b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import cirq\n",
+    "except ImportError:\n",
+    "    print(\"installing cirq...\")\n",
+    "    !pip install --quiet cirq\n",
+    "    print(\"installed cirq.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ba204f38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pytest\n",
+    "import numpy as np\n",
+    "import cirq\n",
+    "from cirq.contrib.svg import SVGCircuit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6358340",
+   "metadata": {},
+   "source": [
+    "A sample circuit is shown as follows along with its ASCII diagram representation and SVG representation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "0a6110b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ───@───────×───Z──────────────────M('z')───\n",
+      "      │       │                      │\n",
+      "1: ───X───@───┼──────────────────────M────────\n",
+      "          │   │                      │\n",
+      "2: ───────@───×───PhX(0.456)^0.123───M────────\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"502.6953125\" height=\"150.0\"><line x1=\"30.0\" x2=\"472.6953125\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"472.6953125\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"472.6953125\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"90.0\" x2=\"90.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"150.0\" x2=\"150.0\" y1=\"75.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"210.0\" x2=\"210.0\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"429.95919921875\" x2=\"429.95919921875\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><rect x=\"10.0\" y=\"105.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">2: </text><circle cx=\"90.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"70.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"150.0\" cy=\"75.0\" r=\"10.0\" /><circle cx=\"150.0\" cy=\"125.0\" r=\"10.0\" /><text x=\"210.0\" y=\"28.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><text x=\"210.0\" y=\"128.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><rect x=\"249.99999999999997\" y=\"105.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"318.61154296875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">PhX(0.456)^0.123</text><rect x=\"249.99999999999997\" y=\"5.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"318.61154296875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">Z</text><rect x=\"407.22308593749995\" y=\"5.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">M('z')</text><rect x=\"407.22308593749995\" y=\"55.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text><rect x=\"407.22308593749995\" y=\"105.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text></svg>"
+      ],
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f63ae6373a0>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a, b, c = cirq.LineQubit.range(3)\n",
+    "circuit1=cirq.Circuit()\n",
+    "circuit1.append(cirq.Moment(cirq.CNOT(a, b)))\n",
+    "circuit1.append(cirq.Moment(cirq.CZ(b, c)))\n",
+    "circuit1.append(cirq.Moment(cirq.SWAP(a, c)))\n",
+    "circuit1.append(cirq.Moment(cirq.PhasedXPowGate(exponent=0.123, phase_exponent=0.456).on(c)))\n",
+    "circuit1.append(cirq.Z(a))\n",
+    "circuit1.append(cirq.Moment(cirq.measure(a, b, c, key='z')))\n",
+    "print(circuit1)\n",
+    "SVGCircuit(circuit1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "246a93ba",
+   "metadata": {},
+   "source": [
+    "Modifying the circuit slightly by adding an empty moment in between, we see the following ASCII circuit diagram: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "d47f8ac7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ───@───────────×───Z──────────────────M('z')───\n",
+      "      │           │                      │\n",
+      "1: ───X───@───────┼──────────────────────M────────\n",
+      "          │       │                      │\n",
+      "2: ───────@───────×───PhX(0.456)^0.123───M────────\n"
+     ]
+    }
+   ],
+   "source": [
+    "a, b, c = cirq.LineQubit.range(3)\n",
+    "circuit2=cirq.Circuit()\n",
+    "circuit2.append(cirq.Moment(cirq.CNOT(a, b)))\n",
+    "circuit2.append(cirq.Moment(cirq.CZ(b, c)))\n",
+    "circuit2.append(cirq.Moment()) # Empty moment included in the circuit\n",
+    "circuit2.append(cirq.Moment(cirq.SWAP(a, c)))\n",
+    "circuit2.append(cirq.Moment(cirq.PhasedXPowGate(exponent=0.123, phase_exponent=0.456).on(c)))\n",
+    "circuit2.append(cirq.Z(a))\n",
+    "circuit2.append(cirq.Moment(cirq.measure(a, b, c, key='z')))\n",
+    "print(circuit2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "060d5746",
+   "metadata": {},
+   "source": [
+    "The ASCII diagram shown above takes into account the empty moment by displaying some space between the second and the third moment:\n",
+    "```\n",
+    "0: ───@───────────×───Z──────────────────M('z')───\n",
+    "      │           │                      │\n",
+    "1: ───X───@───────┼──────────────────────M────────\n",
+    "          │       │                      │\n",
+    "2: ───────@───────×───PhX(0.456)^0.123───M────────\n",
+    "            └───┘\n",
+    "      Empty moment shown by spacing\n",
+    "```\n",
+    "\n",
+    "Circuit._repr_svg_ doesnt take into account empty moments and generates a value error as shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "cc484d37",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Can't draw SVG diagram for circuits with empty moments. Run it through cirq.DropEmptyMoments()",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/anaconda3/envs/cirq-dev-contrib/lib/python3.9/site-packages/IPython/core/formatters.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    343\u001b[0m             \u001b[0mmethod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_real_method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprint_method\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    344\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mmethod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 345\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    346\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    347\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/cirq-dev-contrib/lib/python3.9/site-packages/cirq/contrib/svg/svg.py\u001b[0m in \u001b[0;36m_repr_svg_\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    269\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_repr_svg_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    270\u001b[0m         \u001b[0;31m# coverage: ignore\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 271\u001b[0;31m         \u001b[0m_validate_circuit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcircuit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    272\u001b[0m         \u001b[0mtdd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcircuit\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_text_diagram_drawer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtranspose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    273\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mtdd_to_svg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtdd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/cirq-dev-contrib/lib/python3.9/site-packages/cirq/contrib/svg/svg.py\u001b[0m in \u001b[0;36m_validate_circuit\u001b[0;34m(circuit)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    249\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0many\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmom\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mmom\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mcircuit\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmoments\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 250\u001b[0;31m         raise ValueError(\n\u001b[0m\u001b[1;32m    251\u001b[0m             \u001b[0;34m\"Can't draw SVG diagram for circuits with empty \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    252\u001b[0m             \u001b[0;34m\"moments. Run it through cirq.DropEmptyMoments()\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: Can't draw SVG diagram for circuits with empty moments. Run it through cirq.DropEmptyMoments()"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f63ae5b8940>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "SVGCircuit(circuit2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee5af743",
+   "metadata": {},
+   "source": [
+    "The code generates a value error in the function **_validate_circuit(self.circuit)** itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d07a104b",
+   "metadata": {},
+   "source": [
+    "## Bug fix:\n",
+    "On further analysis of svg.py, by bypassing the validation phase for circuits with empty moments, the function tdd_to_svg(tdd) was modified to add spacing in the svg for empty moments\n",
+    "\n",
+    "The following code sample shows that"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "ac391d10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from svg import SVGCircuit # importted from the modified svg.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "7e113a64",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Circuit without empty moment:\n",
+      "0: ───@───────×───Z──────────────────M('z')───\n",
+      "      │       │                      │\n",
+      "1: ───X───@───┼──────────────────────M────────\n",
+      "          │   │                      │\n",
+      "2: ───────@───×───PhX(0.456)^0.123───M────────\n",
+      "\n",
+      "\n",
+      "\n",
+      "Circuit without empty moment:\n",
+      "0: ───@───────────×───Z──────────────────M('z')───\n",
+      "      │           │                      │\n",
+      "1: ───X───@───────┼──────────────────────M────────\n",
+      "          │       │                      │\n",
+      "2: ───────@───────×───PhX(0.456)^0.123───M────────\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Circuit without empty moment:\")\n",
+    "print(circuit1)\n",
+    "print(\"\\n\\n\")\n",
+    "print(\"Circuit without empty moment:\")\n",
+    "print(circuit2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "469b6521",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Circuit without empty moment:\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"502.6953125\" height=\"150.0\"><line x1=\"30.0\" x2=\"472.6953125\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"472.6953125\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"472.6953125\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"90.0\" x2=\"90.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"150.0\" x2=\"150.0\" y1=\"75.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"210.0\" x2=\"210.0\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"429.95919921875\" x2=\"429.95919921875\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><rect x=\"10.0\" y=\"105.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">2: </text><circle cx=\"90.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"70.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"150.0\" cy=\"75.0\" r=\"10.0\" /><circle cx=\"150.0\" cy=\"125.0\" r=\"10.0\" /><text x=\"210.0\" y=\"28.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><text x=\"210.0\" y=\"128.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><rect x=\"249.99999999999997\" y=\"105.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"318.61154296875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">PhX(0.456)^0.123</text><rect x=\"249.99999999999997\" y=\"5.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"318.61154296875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">Z</text><rect x=\"407.22308593749995\" y=\"5.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">M('z')</text><rect x=\"407.22308593749995\" y=\"55.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text><rect x=\"407.22308593749995\" y=\"105.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"429.95919921875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae5b89d0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"Circuit without empty moment:\")\n",
+    "SVGCircuit(circuit1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "34308519",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Circuit with empty moment:\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"562.6953125\" height=\"150.0\"><line x1=\"30.0\" x2=\"532.6953125\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"532.6953125\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"532.6953125\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"90.0\" x2=\"90.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"150.0\" x2=\"150.0\" y1=\"75.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"270.0\" x2=\"270.0\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"489.95919921875\" x2=\"489.95919921875\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><rect x=\"10.0\" y=\"105.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">2: </text><circle cx=\"90.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"70.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"150.0\" cy=\"75.0\" r=\"10.0\" /><circle cx=\"150.0\" cy=\"125.0\" r=\"10.0\" /><text x=\"270.0\" y=\"28.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><text x=\"270.0\" y=\"128.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><rect x=\"310.0\" y=\"105.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"378.61154296875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">PhX(0.456)^0.123</text><rect x=\"310.0\" y=\"5.0\" width=\"137.2230859375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"378.61154296875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">Z</text><rect x=\"467.22308593749995\" y=\"5.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"489.95919921875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">M('z')</text><rect x=\"467.22308593749995\" y=\"55.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"489.95919921875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text><rect x=\"467.22308593749995\" y=\"105.0\" width=\"45.4722265625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"489.95919921875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae5b8970>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"Circuit with empty moment:\")\n",
+    "SVGCircuit(circuit2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1796f2de",
+   "metadata": {},
+   "source": [
+    "## Other circuit examples are shown as with the corresponding ASCII representation and SVG representation.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc3f2cbb",
+   "metadata": {},
+   "source": [
+    "### 1. Circuits with only empty moments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "89235c25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit3=cirq.Circuit()\n",
+    "circuit3.append([\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment()\n",
+    "])\n",
+    "print(circuit3) # notice that no ASCII diagram is being printed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "3db879d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae637ee0>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "SVGCircuit(circuit3) # generates a blank SVG in such a case"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ee95ab5",
+   "metadata": {},
+   "source": [
+    "### 2. Circuits starting with 1 or more empty moments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "2ff7c3b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ───────────────────@───\n",
+      "                      │\n",
+      "1: ───────────────────X───\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"400.0\" height=\"100.0\"><line x1=\"30.0\" x2=\"370.0\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"370.0\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"330.0\" x2=\"330.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><circle cx=\"330.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"310.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"330.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63aea1f640>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit3.append(cirq.Moment(cirq.CNOT(a,b)))\n",
+    "print(circuit3)\n",
+    "SVGCircuit(circuit3)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4747bea",
+   "metadata": {},
+   "source": [
+    "### 3. Circuits starting with 1 or more empty moments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "cbc9369f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ───────────────────@───────\n",
+      "                      │\n",
+      "1: ───────────────────X───────\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"460.0\" height=\"100.0\"><line x1=\"30.0\" x2=\"430.0\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"430.0\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"330.0\" x2=\"330.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><circle cx=\"330.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"310.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"330.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae6015b0>"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit3.append(cirq.Moment())\n",
+    "print(circuit3)\n",
+    "SVGCircuit(circuit3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e68162",
+   "metadata": {},
+   "source": [
+    "### 4. Circuits without explicitly defined moments and empty moments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "1e62f88e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ───X───D(0.001)[cirq.VirtualTag()]───────D(0.001)[cirq.VirtualTag()]───\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"398.413203125\" height=\"50.0\"><line x1=\"30.0\" x2=\"368.413203125\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"70.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"130.0\" y=\"5.0\" width=\"69.2066015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"164.60330078125\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">D(0.001)</text><rect x=\"279.20660156249994\" y=\"5.0\" width=\"69.2066015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"313.80990234374997\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">D(0.001)</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae636bb0>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "noise_model = cirq.ConstantQubitNoiseModel(cirq.DepolarizingChannel(p=1e-3))\n",
+    "q = cirq.LineQubit(0)\n",
+    "circuit4 = cirq.Circuit(cirq.X(q))\n",
+    "circuit4.append(cirq.Moment())\n",
+    "circuit4 = cirq.Circuit(noise_model.noisy_moments(circuit4.moments, [q]))\n",
+    "print(circuit4)\n",
+    "SVGCircuit(circuit4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "aba44173",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "               ┌──┐       ┌──┐\n",
+      "(0, 0): ───@────@─────@────@─────────────────────────\n",
+      "           │    │     │    │\n",
+      "(0, 1): ───X────┼@────X────┼@────────────────────────\n",
+      "                ││         ││\n",
+      "(1, 0): ───@────X┼────@────X┼────────────────────────\n",
+      "           │     │    │     │\n",
+      "(1, 1): ───X─────X────X─────X────────────────────────\n",
+      "               └──┘       └──┘\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"729.517734375\" height=\"240.0\"><line x1=\"34.7588671875\" x2=\"699.517734375\" y1=\"45.0\" y2=\"45.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"34.7588671875\" x2=\"699.517734375\" y1=\"95.0\" y2=\"95.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"34.7588671875\" x2=\"699.517734375\" y1=\"145.0\" y2=\"145.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"34.7588671875\" x2=\"699.517734375\" y1=\"195.0\" y2=\"195.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"289.51773437500003\" x2=\"379.51773437500003\" y1=\"5.0\" y2=\"5.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"289.51773437500003\" x2=\"379.51773437500003\" y1=\"235.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"129.517734375\" x2=\"219.517734375\" y1=\"5.0\" y2=\"5.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"129.517734375\" x2=\"219.517734375\" y1=\"235.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"99.517734375\" x2=\"99.517734375\" y1=\"45.0\" y2=\"95.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"99.517734375\" x2=\"99.517734375\" y1=\"145.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"149.517734375\" x2=\"149.517734375\" y1=\"45.0\" y2=\"145.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"189.517734375\" x2=\"189.517734375\" y1=\"95.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"259.51773437500003\" x2=\"259.51773437500003\" y1=\"45.0\" y2=\"95.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"259.51773437500003\" x2=\"259.51773437500003\" y1=\"145.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"309.51773437500003\" x2=\"309.51773437500003\" y1=\"45.0\" y2=\"145.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"349.51773437500003\" x2=\"349.51773437500003\" y1=\"95.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"289.51773437500003\" x2=\"289.51773437500003\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"379.51773437500003\" x2=\"379.51773437500003\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"289.51773437500003\" x2=\"289.51773437500003\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"379.51773437500003\" x2=\"379.51773437500003\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"129.517734375\" x2=\"129.517734375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"219.517734375\" x2=\"219.517734375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"129.517734375\" x2=\"129.517734375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"219.517734375\" x2=\"219.517734375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"25.0\" width=\"49.517734375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"34.7588671875\" y=\"45.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 0): </text><rect x=\"10.0\" y=\"75.0\" width=\"49.517734375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"34.7588671875\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 1): </text><rect x=\"10.0\" y=\"125.0\" width=\"49.517734375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"34.7588671875\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(1, 0): </text><rect x=\"10.0\" y=\"175.0\" width=\"49.517734375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"34.7588671875\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(1, 1): </text><circle cx=\"99.517734375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"79.517734375\" y=\"75.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"99.517734375\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"99.517734375\" cy=\"145.0\" r=\"10.0\" /><rect x=\"79.517734375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"99.517734375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"149.517734375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"129.517734375\" y=\"125.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"149.517734375\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"189.517734375\" cy=\"95.0\" r=\"10.0\" /><rect x=\"169.517734375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"189.517734375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"259.51773437500003\" cy=\"45.0\" r=\"10.0\" /><rect x=\"239.51773437500003\" y=\"75.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"259.51773437500003\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"259.51773437500003\" cy=\"145.0\" r=\"10.0\" /><rect x=\"239.51773437500003\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"259.51773437500003\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"309.51773437500003\" cy=\"45.0\" r=\"10.0\" /><rect x=\"289.51773437500003\" y=\"125.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"309.51773437500003\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"349.51773437500003\" cy=\"95.0\" r=\"10.0\" /><rect x=\"329.51773437500003\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"349.51773437500003\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae5c0520>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuit5=cirq.Circuit(\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(0,1)),\n",
+    "    cirq.CNOT(cirq.GridQubit(1,0), cirq.GridQubit(1,1)),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(1,0)),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.Moment(),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(0,1)),\n",
+    "    cirq.CNOT(cirq.GridQubit(1,0), cirq.GridQubit(1,1)),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(1,0)),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),\n",
+    ")\n",
+    "print(circuit5)\n",
+    "SVGCircuit(circuit5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "4640a5dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"220.0\" height=\"50.0\"><line x1=\"30.0\" x2=\"190.0\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"70.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>"
+      ],
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f63ae5dfcd0>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q0 = cirq.LineQubit(0)\n",
+    "SVGCircuit(cirq.Circuit([cirq.Moment([cirq.X(q0)]), cirq.Moment([])]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cirq-core/cirq/contrib/svg/example.ipynb
+++ b/cirq-core/cirq/contrib/svg/example.ipynb
@@ -2,11 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bd9529db1c0b"
-   },
-   "outputs": [],
+   "execution_count": 1,
    "source": [
     "try:\n",
     "    import cirq\n",
@@ -14,23 +10,25 @@
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "id": "bd9529db1c0b"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
    "source": [
     "import cirq\n",
     "from cirq.contrib.svg import SVGCircuit"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
    "source": [
     "a, b, c = cirq.LineQubit.range(3)\n",
     "SVGCircuit(cirq.Circuit(\n",
@@ -41,13 +39,25 @@
     "    cirq.Z(a),\n",
     "    cirq.measure(a, b, c, key='z')\n",
     "))"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"482.4951171875\" height=\"150.0\"><line x1=\"30.0\" x2=\"452.4951171875\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"452.4951171875\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"30.0\" x2=\"452.4951171875\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"90.0\" x2=\"90.0\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"150.0\" x2=\"150.0\" y1=\"75.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"210.0\" x2=\"210.0\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"411.6015625\" x2=\"411.6015625\" y1=\"25.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">0: </text><rect x=\"10.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">1: </text><rect x=\"10.0\" y=\"105.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"30.0\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">2: </text><circle cx=\"90.0\" cy=\"25.0\" r=\"10.0\" /><rect x=\"70.0\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"90.0\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"150.0\" cy=\"75.0\" r=\"10.0\" /><circle cx=\"150.0\" cy=\"125.0\" r=\"10.0\" /><text x=\"210.0\" y=\"28.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><text x=\"210.0\" y=\"128.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"40px\" font-family=\"Arial\">×</text><rect x=\"250.0\" y=\"105.0\" width=\"120.7080078125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"310.35400390625\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">PhX(0.456)^0.123</text><rect x=\"250.0\" y=\"5.0\" width=\"120.7080078125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"310.35400390625\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">Z</text><rect x=\"390.7080078125\" y=\"5.0\" width=\"41.787109375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"411.6015625\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">M('z')</text><rect x=\"390.7080078125\" y=\"55.0\" width=\"41.787109375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"411.6015625\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text><rect x=\"390.7080078125\" y=\"105.0\" width=\"41.787109375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"411.6015625\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">M</text></svg>",
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f178a62df40>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
    "source": [
     "SVGCircuit(cirq.Circuit(\n",
     "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(0,1)),\n",
@@ -59,14 +69,27 @@
     "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(1,0)),\n",
     "    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),\n",
     "))"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"424.49359375\" height=\"240.0\"><line x1=\"32.246796875\" x2=\"394.49359375\" y1=\"45.0\" y2=\"45.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"394.49359375\" y1=\"95.0\" y2=\"95.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"394.49359375\" y1=\"145.0\" y2=\"145.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"394.49359375\" y1=\"195.0\" y2=\"195.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"284.49359375\" x2=\"374.49359375\" y1=\"5.0\" y2=\"5.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"284.49359375\" x2=\"374.49359375\" y1=\"235.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"124.49359375\" x2=\"214.49359375\" y1=\"5.0\" y2=\"5.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"124.49359375\" x2=\"214.49359375\" y1=\"235.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"1\" /><line x1=\"94.49359375\" x2=\"94.49359375\" y1=\"45.0\" y2=\"95.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"94.49359375\" x2=\"94.49359375\" y1=\"145.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"144.49359375\" x2=\"144.49359375\" y1=\"45.0\" y2=\"145.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"184.49359375\" x2=\"184.49359375\" y1=\"95.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"254.49359375\" x2=\"254.49359375\" y1=\"45.0\" y2=\"95.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"254.49359375\" x2=\"254.49359375\" y1=\"145.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"304.49359375\" x2=\"304.49359375\" y1=\"45.0\" y2=\"145.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"344.49359375\" x2=\"344.49359375\" y1=\"95.0\" y2=\"195.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"284.49359375\" x2=\"284.49359375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"374.49359375\" x2=\"374.49359375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"284.49359375\" x2=\"284.49359375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"374.49359375\" x2=\"374.49359375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"124.49359375\" x2=\"124.49359375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"214.49359375\" x2=\"214.49359375\" y1=\"5.0\" y2=\"15.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"124.49359375\" x2=\"124.49359375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"214.49359375\" x2=\"214.49359375\" y1=\"225.0\" y2=\"235.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"25.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"45.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 0): </text><rect x=\"10.0\" y=\"75.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 1): </text><rect x=\"10.0\" y=\"125.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(1, 0): </text><rect x=\"10.0\" y=\"175.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(1, 1): </text><circle cx=\"94.49359375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"74.49359375\" y=\"75.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"94.49359375\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"94.49359375\" cy=\"145.0\" r=\"10.0\" /><rect x=\"74.49359375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"94.49359375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"144.49359375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"124.49359375\" y=\"125.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"144.49359375\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"184.49359375\" cy=\"95.0\" r=\"10.0\" /><rect x=\"164.49359375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"184.49359375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"254.49359375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"234.49359375\" y=\"75.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"254.49359375\" y=\"95.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"254.49359375\" cy=\"145.0\" r=\"10.0\" /><rect x=\"234.49359375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"254.49359375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"304.49359375\" cy=\"45.0\" r=\"10.0\" /><rect x=\"284.49359375\" y=\"125.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"304.49359375\" y=\"145.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><circle cx=\"344.49359375\" cy=\"95.0\" r=\"10.0\" /><rect x=\"324.49359375\" y=\"175.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"344.49359375\" y=\"195.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>",
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f178a5ef940>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 4
+    }
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit ('qdev': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -78,7 +101,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
+  },
+  "interpreter": {
+   "hash": "220d3178c6e966d2ac80709dfa60cf34f328a3e7f9db8d724cad1b9f3cd3a337"
   }
  },
  "nbformat": 4,

--- a/cirq-core/cirq/contrib/svg/svg.ipynb
+++ b/cirq-core/cirq/contrib/svg/svg.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "import cirq\n",
+    "from cirq.contrib.svg import SVGCircuit"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "cirq.Moment()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "a, b = cirq.LineQubit.range(2)\n",
+    "c = cirq.Circuit(cirq.H(a), cirq.CNOT(a, b))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "print(repr(c))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "c"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "SVGCircuit(c)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "c.append(cirq.Moment())\n",
+    "c.append(cirq.Moment(cirq.H(a)))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "c"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "SVGCircuit(c)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "print(repr(c))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "c.append(cirq.MatrixGate(cirq.unitary(cirq.H)).on(a))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "220d3178c6e966d2ac80709dfa60cf34f328a3e7f9db8d724cad1b9f3cd3a337"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit ('qdev': conda)"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 import cirq
-from cirq.contrib.svg import circuit_to_svg
+from svg import circuit_to_svg
 
 
 def test_svg():
@@ -36,6 +36,21 @@ def test_validation():
     with pytest.raises(ValueError):
         circuit_to_svg(cirq.Circuit())
 
-    q0 = cirq.LineQubit(0)
-    with pytest.raises(ValueError):
-        circuit_to_svg(cirq.Circuit([cirq.Moment([cirq.X(q0)]), cirq.Moment([])]))
+
+def test_empty_moments():
+    a, b, c = cirq.LineQubit.range(3)
+    svg_text = circuit_to_svg(
+        cirq.Circuit(
+            (cirq.Moment(cirq.CNOT(a, b))),
+            (cirq.Moment(cirq.CZ(b, c))),
+            # Empty moment included in the circuit,
+            (cirq.Moment()),
+            (cirq.Moment(cirq.SWAP(a, c))),
+            (cirq.Moment(cirq.PhasedXPowGate(exponent=0.123, phase_exponent=0.456).on(c))),
+            (cirq.Z(a)),
+            (cirq.Moment(cirq.measure(a, b, c, key='z')))
+        )
+    )
+    print(svg_text)
+    assert '<svg' in svg_text
+    assert '</svg>' in svg_text


### PR DESCRIPTION
This PR aims to  solve the bugs in the issue [#4499](https://github.com/quantumlib/Cirq/issues/4499)

### Listed bugs in [#4499](https://github.com/quantumlib/Cirq/issues/4499)

- [x] Take care of the SVG circuits when the `cirq.Moment()` is empty (Currently, it fails).
- [ ]  Implement a fix that no longer requires circuits to not require integer coordinates for spacing routines.
- [ ] Implement a dynamic horizontal spacing framework for the rows in the SVGs of the circuits.